### PR TITLE
removed npm version tag(?) from packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/card-react-form-container.js",
   "dependencies": {
     "classnames": "^2.1.2",
-    "payment": "2.0.3npm version",
+    "payment": "2.0.3",
     "react": "^15.2.1",
     "react-dom": "^15.2.1"
   },


### PR DESCRIPTION
 Fails the install. Not sure f it has a purpose there. 
